### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,8 +4,7 @@ url = "https://pypi.org/simple"
 verify_ssl = true
 
 [packages]
-python-Levenshtein = "*"
-fuzzywuzzy = "*"
+rapidfuzz = "*"
 passporteye = "*"
 requests = "*"
 flask = "*"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-python-Levenshtein
-fuzzywuzzy
+rapidfuzz
 passporteye
 requests

--- a/verifydocs.py
+++ b/verifydocs.py
@@ -1,6 +1,6 @@
 from passporteye import read_mrz
 import requests
-from fuzzywuzzy import fuzz
+from rapidfuzz import fuzz
 
 
 def verify_npi(npi):
@@ -80,13 +80,13 @@ def validate_passport(url, force_flag=False, threshold=70, url_type=True):
 
 def compare(Str1, Str2, exact=False):
     if exact:
-        if Str1 == Str2:
-            return 1
-        else:
-            return 0
-    Ratio = fuzz.ratio(Str1.lower(), Str2.lower())
-    Partial_Ratio = fuzz.partial_ratio(Str2.lower(), Str1.lower())
-    if Ratio >= 70 or Partial_Ratio >= 70:
+        return Str1 == Str2
+
+    str1_lower = Str1.lower()
+    str2_lower = Str2.lower()
+    Ratio = fuzz.ratio(str1_lower, str2_lower, score_cutoff=70)
+    Partial_Ratio = fuzz.partial_ratio(str1_lower, str2_lower, score_cutoff=70)
+    if Ratio or Partial_Ratio:
         return 1
     else:
         return 0


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2.
For this reason this Pullrequest replaces FuzzyWuzzy with  [rapidfuzz](https://github.com/rhasspy/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed.
Rapidfuzz is:
- Mit licensed so it can be used with the license used by this project
- Is faster than FuzzyWuzzy